### PR TITLE
fixing hash in child_url

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -47,7 +47,6 @@ var pym = (function() {
             var hash = '';
             var hashIndex = this.url.indexOf('#');
 
-            console.log(hashIndex, this.url, hash);
             if (hashIndex > -1) {
                 hash = this.url.substring(hashIndex, this.url.length);
                 this.url = this.url.substring(0, hashIndex);


### PR DESCRIPTION
I move the hash (fragment id) to the end of the url. Fix for nprapps/pym.js/issues/30
