### PR TITLE
Single quotes are not valid JSON, bower complains

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "pym.js",
     "version": "0.1.0",
     "homepage": "http://blog.apps.npr.org/pym.js/",
-    "authors": ['NPR'],
+    "authors": ["NPR"],
     "description": "Resize an iframe responsively depending on the height of its content and the width of its container.",
     "main": "src/pym.js",
     "keywords": [


### PR DESCRIPTION
Tried to `bower install pym.js` today and get `EMALFORMED Failed to read pym.js/bower.json`. The recent commit 5f00f574 that added values to the `authors` field (and flipped the line-endings, apparently), introduced the bug. This should correct.
