### PR TITLE
Run `grunt jshint` as a sanity check before release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,49 @@
+/*global module:false*/
+module.exports = function(grunt) {
+
+  // Project configuration.
+  grunt.initConfig({
+    // Task configuration.
+    jshint: {
+      options: {
+        curly: true,
+        eqeqeq: true,
+        immed: true,
+        latedef: true,
+        newcap: true,
+        noarg: true,
+        sub: true,
+        undef: true,
+        unused: true,
+        boss: true,
+        eqnull: true,
+      },
+      files: [
+        "Gruntfile.js",
+        "bower.json",
+        "package.json",
+      ],
+      lib: {
+        src: "src/**/*.js",
+      }
+    },
+    watch: {
+      jshint: {
+        files: "<%= jshint.files  %>",
+        tasks: ["jshint"]
+      },
+      lib: {
+        files: "<%= jshint.lib.src %>",
+        tasks: ["jshint:lib"]
+      }
+    }
+  });
+
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks("grunt-contrib-jshint");
+  grunt.loadNpmTasks("grunt-contrib-watch");
+
+  // Default task.
+  grunt.registerTask("default", ["jshint"]);
+
+};

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/nprapps/pym.js/issues"
+    },
+    "devDependencies": {
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jshint": "~0.10.0"
     }
 }


### PR DESCRIPTION
The default Grunt task will run `jshint` on `Gruntfile.js`, `bower.json`, `package.json` and the contents of `src/`, but I've split the meta files from the library into a separate target because `pym.js` doesn't pass inspection with the default options. Tweak to suit.
