### PR TITLE
Introduce 'autoinit' feature

### DIFF
--- a/examples/autoinit/child.html
+++ b/examples/autoinit/child.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
+</head>
+<body>
+    <div>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <p>Aliquam rhoncus elit id velit pharetra sodales. Sed eu tellus in orci vestibulum elementum.</p>
+        <p>Aliquam erat volutpat. In pharetra neque a massa pretium hendrerit.</p>
+        <p>Ut aliquet lorem sed est tincidunt semper. Suspendisse ut diam tortor, ac porttitor tellus.</p>
+        <p>Donec sit amet sapien at magna facilisis facilisis. Vivamus eget libero ac diam molestie cursus.</p>
+        <p>Nulla mauris lectus, ullamcorper vitae blandit sit amet, tempus eget nisi. Ut id lacus ut sem adipiscing rutrum vel sit amet neque.</p>
+        <p>Nullam egestas porttitor risus, at ultricies mi tristique ac. Praesent fermentum ipsum rhoncus lorem scelerisque quis venenatis lacus sagittis. Aenean aliquam, nunc ut sollicitudin suscipit, metus massa sodales justo, quis convallis tellus turpis a nunc. Integer lacinia erat ut dolor rhoncus eu venenatis dolor luctus. Aenean sit amet diam sed erat sagittis tempus. Quisque sed ultrices nunc. Nullam tempus commodo tortor. Fusce at cursus est. Vestibulum euismod odio nisl, congue congue lectus. Donec ac nunc nec sapien volutpat aliquet et a turpis. Nulla eget ipsum arcu. Suspendisse facilisis dignissim elementum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi sem ante, viverra nec tristique placerat, imperdiet in augue. Sed vel tempus justo. Sed ac odio at massa iaculis dignissim ut sed tellus. Cras in diam et lorem congue fermentum. Ut porta lectus a risus dapibus bibendum. Vivamus eget felis purus, tristique pretium diam. Vivamus enim sapien, consectetur sit amet euismod a, porttitor a quam. Morbi ac arcu nec purus interdum egestas at non magna. Mauris vel nibh leo, ac ullamcorper dolor. Donec ullamcorper purus dapibus odio varius tempus. Etiam scelerisque, urna cursus feugiat scelerisque, libero ante ultrices odio, sed tempor ante enim non ante. Proin eu nibh eget nunc ornare vulputate. Nullam in rhoncus eros. Nunc vel faucibus sem. Sed vel dignissim sapien. Praesent a erat a sapien ullamcorper varius. Duis purus mi, molestie vitae ultricies at, dignissim quis lectus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin non ante ut sapien fringilla ornare a ac metus. Mauris vitae enim libero. Integer tortor libero, volutpat eu gravida sit amet, ultrices non est. Curabitur eget sapien lorem, nec ullamcorper nisl. Maecenas nisl lorem, blandit in rhoncus ut, hendrerit vel metus. Phasellus diam quam, tristique nec vehicula nec, cursus nec eros. Duis odio metus, tincidunt ac bibendum sodales, tristique quis diam. Aenean imperdiet dui quis elit ornare suscipit. Nulla a fringilla nisl. Nulla facilisi. Nulla ut magna ac erat dapibus tempor et et nisl. Integer aliquet, dui eget pharetra dapibus, sapien neque aliquet diam, non molestie mi risus et dolor. Aliquam non ultrices nibh. Duis sed urna dolor. Etiam vitae dolor arcu, quis lacinia ligula. Vestibulum auctor mattis adipiscing. Integer condimentum, tellus sed commodo bibendum, justo quam pharetra nisl, vel viverra ipsum quam at purus. Aliquam aliquet velit imperdiet leo consequat quis tempor neque aliquam. Pellentesque aliquet varius porttitor. Nulla facilisi. Aenean nec tempor elit. Morbi nec congue lectus.</p>
+    </div>
+
+    <script src="../../src/pym.js" type="text/javascript"></script>
+    <script>var pymChild = new pym.Child();</script>
+</body>
+</html>

--- a/examples/autoinit/index.html
+++ b/examples/autoinit/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
+
+</head>
+<body>
+    <div data-pym-src="child.html"></div>
+    <script type="text/javascript" src="../../src/pym.js" data-pym-autoinit></script>
+</body>
+</html>

--- a/src/pym.js
+++ b/src/pym.js
@@ -19,6 +19,35 @@ var pym = (function() {
         return true;
     }
 
+    var _autoInit = function() {
+      var elements = document.querySelectorAll(
+        '[data-pym-src]:not([data-pym-auto-initialized])'
+     );
+      var idx, length, element, id, src, xdomain, config;
+
+       for (idx = 0, length = elements.length; idx < length; ++idx) {
+         element = elements[idx];
+
+         /**
+          * Mark automatically-initialized elements so they are not
+          * re-initialized if the user includes pym.js more thance once in the
+          * same document.
+          */
+         element.setAttribute('data-pym-auto-initialized', '');
+
+         id = element.id = 'pym_' + idx;
+         src = element.getAttribute('data-pym-src');
+         xdomain = element.getAttribute('data-pym-xdomain');
+         config = {};
+
+         if (xdomain) {
+           config.xdomain = xdomain;
+         }
+
+         lib.Parent(id, src, config);
+       }
+    };
+
     lib.Parent = function(id, url, config) {
         /*
         * A global function for setting up a responsive parent.
@@ -244,6 +273,10 @@ var pym = (function() {
 
         return this;
     };
+
+    if (document.querySelector('script[data-pym-autoinit]')) {
+      _autoInit();
+    }
 
     return lib;
 }());


### PR DESCRIPTION
As originally proposed in issue #41:

> My use-case for pym.js is similar to the motivating example in the project website (embedding an iframe in a CMS document), but I have an additional restriction: the CMS actively scrubs in-line JavaScript. I would like to instruct pym.js to automatically instantiate a parent connection on iframes that opt-in to the functionality.

There, @onyxfish share the following feedback:

> [...] it seems like the `data-pym-autoinit` property shouldn't be necessary. Ideally there would just be something on each div identifying what pym should do with it.

That proparty is a bit of an optimization; it allows pym to skip the automatic initialization code path for all the users that don't need it. On the other hand, it makes the feature a little harder to discover/use. I'm happy to remove it; I just wanted to make sure the trade off was understood first. Let me know!

Commit message:

> Enable the automatic creation of iframes when the script tag which
> included Pym.js contains a `data-pym-autoinit` attribute. Ensure that
> duplicate iframes are not created in cases where pym.js is included more
> than once in the same document.
