### PR TITLE
Fix error with polling

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -429,7 +429,7 @@
             var height = document.getElementsByTagName('body')[0].offsetHeight.toString();
 
             // Send the height to the parent.
-            this.sendMessage('height', height);
+            that.sendMessage('height', height);
         };
 
         /**


### PR DESCRIPTION
If you call `var pymChild = new pym.Child({polling: 1000});`you get the followinf error because 'this'
 is the iframes windo object instead of the pym.Child object.

```
Uncaught TypeError: undefined is not a function pym.js:432
  lib.Child.sendHeight pym.js:432
```
