### PR TITLE
give a warning if the body position isn't static

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -330,6 +330,14 @@
         this.messageRegex = null;
         this.messageHandlers = {};
 
+        try {
+            var bodyStyle = window.getComputedStyle(document.getElementsByTagName('body')[0])
+            if (bodyStyle.position != 'static') {
+                console.warn('The <body> element style for child iframes should remain static for pym.js to size them properly.');
+            }
+        }
+        catch(e) { }
+
         /**
          * Bind a callback to a given messageType from the child.
          *


### PR DESCRIPTION
If you set the body tag position to absolute or fixed and the height to 100% of a child iframe, the iframe will not resize. If you set the height to a percentage that is less than 100%, the iframe shrinks every resize.

[demo](https://github.com/zippy1981/pym.js-body-bug-demo).

I think this deserves a console.warn. I'm open to other ideas on how to deal with this behavior.
