### PR TITLE
Adding IE8 Support

### DIFF
--- a/dist/pym.js
+++ b/dist/pym.js
@@ -1,4 +1,4 @@
-/*! pym.js - v0.4.1 - 2014-12-12 */
+/*! pym.js - v0.4.1 - 2016-03-22 */
 /*
 * Pym.js is library that resizes an iframe based on the width of the parent and the resulting height of the child.
 * Check out the docs at http://blog.apps.npr.org/pym.js/ or the readme at README.md for usage.
@@ -54,6 +54,15 @@
         return true;
     };
 
+    var _addEventListener = function(on, fn, useCapture) {
+        if(document.addEventListener) {
+            window.addEventListener(on, fn, useCapture);
+        } else {
+            on = 'on' + on;
+            window.attachEvent(on, fn);
+        }
+    }
+
     /**
      * Construct a message to send between frames.
      *
@@ -89,14 +98,15 @@
      * @method _autoInit
      */
     var _autoInit = function() {
-        var elements = document.querySelectorAll(
-            '[data-pym-src]:not([data-pym-auto-initialized])'
-        );
+        var elements = document.querySelectorAll('[data-pym-src]');
 
         var length = elements.length;
 
         for (var idx = 0; idx < length; ++idx) {
             var element = elements[idx];
+            if(element.getAttribute('data-pym-auto-initialized') !== null) {
+                continue;
+            }
 
             /*
             * Mark automatically-initialized elements so they are not
@@ -187,7 +197,7 @@
 
             // Add an event listener that will handle redrawing the child on resize.
             var that = this;
-            window.addEventListener('resize', function() {
+            _addEventListener('resize', function() {
                 that.sendWidth();
             });
         };
@@ -306,7 +316,8 @@
 
         // Add a listener for processing messages from the child.
         var that = this;
-        window.addEventListener('message', function(e) {
+
+        _addEventListener('message', function(e) {
             return that._processMessage(e);
         }, false);
 
@@ -481,7 +492,7 @@
 
         // Set up a listener to handle any incoming messages.
         var that = this;
-        window.addEventListener('message', function(e) {
+        _addEventListener('message', function(e) {
             that._processMessage(e);
         }, false);
 

--- a/examples/events/child.html
+++ b/examples/events/child.html
@@ -14,7 +14,9 @@
         var pymChild = new pym.Child();
 
         function onClick(e) {
-            e.preventDefault();
+            if(event.preventDefault) event.preventDefault();
+            event.returnValue = false;
+            
             pymChild.sendMessage('child-click', 'Child clicked!');
         }
 
@@ -23,7 +25,12 @@
             pymChild.sendHeight();
         });
 
-        document.getElementById('test').addEventListener('click', onClick);
+        var el = document.getElementById('test');
+        if(el.addEventListener) {
+            el.addEventListener('click', onClick);
+        } else {
+            el.attachEvent('onclick', onClick); 
+        }
 
     </script>
 </body>

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -16,7 +16,9 @@
         var pymParent = new pym.Parent('example', 'child.html', {});
 
         function onClick(e) {
-            e.preventDefault();
+            if(event.preventDefault) event.preventDefault();
+            event.returnValue = false;
+
             pymParent.sendMessage('parent-click', 'Parent clicked!');
         }
 
@@ -24,7 +26,12 @@
              document.getElementById('from-child').innerHTML = data;
         });
 
-        document.getElementById('test').addEventListener('click', onClick);
+        var el = document.getElementById('test');
+        if(el.addEventListener) {
+            el.addEventListener('click', onClick);
+        } else {
+            el.attachEvent('onclick', onClick); 
+        }
     </script>
 </body>
 </html>

--- a/src/pym.js
+++ b/src/pym.js
@@ -53,6 +53,15 @@
         return true;
     };
 
+    var _addEventListener = function(on, fn, useCapture) {
+        if(document.addEventListener) {
+            window.addEventListener(on, fn, useCapture);
+        } else {
+            on = 'on' + on;
+            window.attachEvent(on, fn);
+        }
+    }
+
     /**
      * Construct a message to send between frames.
      *
@@ -88,14 +97,15 @@
      * @method _autoInit
      */
     var _autoInit = function() {
-        var elements = document.querySelectorAll(
-            '[data-pym-src]:not([data-pym-auto-initialized])'
-        );
+        var elements = document.querySelectorAll('[data-pym-src]');
 
         var length = elements.length;
 
         for (var idx = 0; idx < length; ++idx) {
             var element = elements[idx];
+            if(element.getAttribute('data-pym-auto-initialized') !== null) {
+                continue;
+            }
 
             /*
             * Mark automatically-initialized elements so they are not
@@ -186,7 +196,7 @@
 
             // Add an event listener that will handle redrawing the child on resize.
             var that = this;
-            window.addEventListener('resize', function() {
+            _addEventListener('resize', function() {
                 that.sendWidth();
             });
         };
@@ -305,7 +315,8 @@
 
         // Add a listener for processing messages from the child.
         var that = this;
-        window.addEventListener('message', function(e) {
+
+        /*window.addEventListener*/_addEventListener('message', function(e) {
             return that._processMessage(e);
         }, false);
 
@@ -480,7 +491,7 @@
 
         // Set up a listener to handle any incoming messages.
         var that = this;
-        window.addEventListener('message', function(e) {
+        _addEventListener('message', function(e) {
             that._processMessage(e);
         }, false);
 

--- a/src/pym.js
+++ b/src/pym.js
@@ -316,7 +316,7 @@
         // Add a listener for processing messages from the child.
         var that = this;
 
-        /*window.addEventListener*/_addEventListener('message', function(e) {
+        _addEventListener('message', function(e) {
             return that._processMessage(e);
         }, false);
 


### PR DESCRIPTION
Support IE8 required a couple of minor changes:
- Using `window.attachEvent` if `window.addEventListener` doesn't exist.
- The usage of the `:not` selector in autoinit, so I replaced that with a check for if the `data-pym-auto-initialized` attr has been set when iterating over each element that matches `[data-pym-src]`.

The examples should all work in IE8 except the one that use D3.
