### PR TITLE
Limit npm installed files to just the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "responsive",
     "browser"
   ],
+  "files": [
+    "dist"
+  ],
   "author": "NPR",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This ties into #75 – if the npm installed version points at `dist/pym.js` instead of `src/pym.js`, then the `src` and `examples` folders aren't needed at all during an `npm install`.

I didn't make the change in the `bower.json` as well (it already ignores the `examples` folder), but if the change over from #75 gets accepted then `src` could be added to the `ignore` array in there.