### PR TITLE
Remove errant parentheses on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Additional contributors:
 * [Thomas Wilburn](https://github.com/thomaswilburn)
 * [Justin Dearing](https://github.com/zippy1981)
 * [Chris Amico](https://github.com/eyeseast)
-* [Ryan Murphy](https://github.com/rdmurphy))
+* [Ryan Murphy](https://github.com/rdmurphy)


### PR DESCRIPTION
Looks like a duplicate trailing parentheses on the markdown format for Ryan Murphy's link. This shows through on the page once rendered after Ryan's name; I would imagine that Ryan is anything but parenthetical.