### PR TITLE
make auto-loaded parents available programatically

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -88,11 +88,14 @@
      * @method _autoInit
      */
     var _autoInit = function() {
+        var parent;
+        
         var elements = document.querySelectorAll(
             '[data-pym-src]:not([data-pym-auto-initialized])'
         );
 
-        var length = elements.length;
+        var autoloaded = [];
+        var length     = elements.length;
 
         for (var idx = 0; idx < length; ++idx) {
             var element = elements[idx];
@@ -117,8 +120,14 @@
                config.xdomain = xdomain;
             }
 
-            new lib.Parent(element.id, src, config);
+            parent = new lib.Parent(element.id, src, config);
+            
+            autoloaded.push(parent);
+            autoloaded[element.id] = parent;
         }
+        
+        if (autoloaded.length)
+            lib.autoloaded = autoloaded;
     };
 
     /**


### PR DESCRIPTION
it handy to be able to reference auto-loaded `pym.Parent` instances. 

if any instances are auto-loaded `pym.autoloaded` will be an `Array` of those instances, instances are also available via object properties on the Array object that match their `element.id` value. 

e.g.

```javascript

var pym  = require('pym');
var me1  = pym.autoloaded[0];
var me2 = pym.autoloaded['example'];

console.log(me1 === me2); // outputs "true", assuming the first autoloaded parent is bound to an DOM element with an id set to "example".
```