### PR TITLE
	modified:   src/pym.js

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -158,6 +158,9 @@
             // Create an iframe element attached to the document.
             this.iframe = document.createElement('iframe');
 
+            // Replace hex with '&' to preserve URL parameters.
+            this.url = this.url.replace(/&#038;/g, "&");
+
             // Save fragment id
             var hash = '';
             var hashIndex = this.url.indexOf('#');


### PR DESCRIPTION
This is my first pull request on Github, so I hope this works. 

I put in a line to prevent the original URL parameters from being lost. I was finding that any GET parameters after the first one were being lost because '&' was being turned to '&#038;' and the '#' was additionally tripping up the location of the "hashIndex" var.

Edit: On second thought, the html special char is probably Wordpress's fault. Still, this is a workaround for people who use WP. I'm sure there's a more elegant implementation than this one-liner.