### PR TITLE
Base height off of HTML document instead of <body>

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -813,7 +813,7 @@
          */
         this.sendHeight = function() {
             // Get the child's height.
-            var height = document.getElementsByTagName('body')[0].offsetHeight.toString();
+            var height = document.documentElement.offsetHeight.toString();
 
             // Send the height to the parent.
             this.sendMessage('height', height);
@@ -979,4 +979,3 @@
 
     return lib;
 });
-

--- a/test/pym/pym.child.test.js
+++ b/test/pym/pym.child.test.js
@@ -37,7 +37,7 @@ describe('pymChild', function() {
     };
 
     beforeEach(function() {
-        document.body.style.height = height+"px";
+        document.documentElement.style.height = height+"px";
         document.body.innerHTML = __html__['test/html-fixtures/child_template.html'];
         spyOn(stub, 'callback').and.callThrough();
     });


### PR DESCRIPTION
Hello! I'll preface this pull request with an acknowledgement that I'm not 100% how substantial of a change this would be. Could be major version level. (If you accept it at all, of course!)

@TylerFisher added an issue for this in #152, but my brain got stuck on it so I started playing.

A very common issue folks have with Pym.js is the funkiness that can happen sometimes with getting the height of a child frame that includes any margins pushing up against the `<body>` element, or with margins pushing down at the end of a document. Both can lead to some very confusing cutting off of the bottom of an embed.

I think the cause of this is Pym's use of `document.getElementsByTagName('body')[0].offsetHeight` to get the page's height. This ignores any margins the `<body>` tag has itself, *and* it ignores any margins overlapping with the `<body>` tag's margins due to margin collapsing. This is why you'll get this problem even if you use one of those clever resets that remove `<body>`'s default browser margins.

The best solution I've found for this is to use the `<html>` element's height instead. Nothing can overflow past the `<html>` element (err, that I've found yet), and in no browser have I found where it has margins by default. The height of `<html>` catches anything on `<body>` and anything with margins pushing past it.

So this is what this pull request does! Someone did a variation of this in a fork way back in #64, but it tried to account for `scrollHeight` too, which I believe you *don't* want. That surfaced some crazy big heights in my tests.

I had to alter the test runner in one place to make this pass — I may not have done that the right way. I'm not sure where `margin` comes into play with karma's HTML test runner. (Ironically, this may be an issue similar to what this is trying address.)

While it's good I got it to pass all the tests, this "solution" could definitely use some stress testing.

Thanks!