### PR TITLE
Verify that messages are actually from our child or parent

### DIFF
--- a/src/pym.js
+++ b/src/pym.js
@@ -78,7 +78,7 @@
         // Adapted from angular 2 url sanitizer
         var SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp):|[^&:/?#]*(?:[/?#]|$))/gi;
         if (!url.match(SAFE_URL_PATTERN)) { return; }
-        
+
         return true;
     };
 
@@ -519,7 +519,12 @@
          * @param {Event} e A message event.
          */
         this._processMessage = function(e) {
-            // First, punt if this isn't from an acceptable xdomain.
+            // Check that the message is actually from our iframe
+            if (e.source !== this.iframe.contentWindow) {
+              return;
+            }
+
+            // Punt if this isn't from an acceptable xdomain.
             if (!_isSafeMessage(e, this.settings)) {
                 return;
             }
@@ -859,7 +864,12 @@
             /*
             * Process a new message from parent frame.
             */
-            // First, punt if this isn't from an acceptable xdomain.
+            // Check that the message is actually from the parent frame
+            if (e.source !== window.parent) {
+              return;
+            }
+
+            // Punt if this isn't from an acceptable xdomain.
             if (!_isSafeMessage(e, this.settings)) {
                 return;
             }
@@ -1116,4 +1126,3 @@
 
     return lib;
 });
-

--- a/src/pym.js
+++ b/src/pym.js
@@ -520,7 +520,10 @@
          */
         this._processMessage = function(e) {
             // Check that the message is actually from our iframe
-            if (e.source !== this.iframe.contentWindow) {
+            // Use the same technique as sendMessage(), since
+            // this.iframe is apparently unreliable
+            var iframes = this.el.getElementsByTagName('iframe');
+            if (iframes.length < 1 || e.source !== iframes[0].contentWindow) {
               return;
             }
 


### PR DESCRIPTION
This change adds a check to the _processMessage functions, verifying that the message's sender (the event.source property) is the child iframe (in the case of pym.Parent) or the parent (in the case of pym.Child). Adding this check significantly reduces the attack surface for vulnerabilities similar to the one recently found, and it brings pym's behavior in line with most users' mental model.

There are two issues that should be considered before merging this:
* I'm not sure exactly how broad pym's set of supported browsers is, but [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/source) the event.source property isn't supported by some very old browsers. It would be possible to have the check pass if event.source is undefined, retaining support for those browsers without any new security guarantees, but this PR chooses the paranoid option of insisting that that event.source be set.

* The pym.Child tests are failing, because the test messages are being sent from the local window itself rather than from the parent as they would be in real use. I'm not familiar enough with the testing framework to modify the tests so that they're actually running in an iframe, and I assume the tests are written as they are because that's a non-trivial undertaking. It would be possible to relax the check so that it also passes for messages sent by the window itself, but changing behavior to accommodate the testing system feels like a bad practice.

I'm happy to address both of these issues based on maintainer guidance.